### PR TITLE
Network and pathway models: intro and transcriptomics section

### DIFF
--- a/content/04.network-models.md
+++ b/content/04.network-models.md
@@ -23,12 +23,12 @@ Combining gene expression data with a network-derived smoothing term has also be
 PIMKL [@doi:10.1038/s41540-019-0086-3] combines network and pathway data to predict disease-free survival from breast cancer cohorts.
 This method takes as input both RNA-seq gene expression data and copy number alteration data, but can be applied to gene expression data alone as well.
 
-Gene regulatory networks can also form a useful component of models for gene expression data.
+Gene regulatory networks can also augment models for gene expression data.
 These networks describe how the expression of genes is modulated by biological regulators such as transcription factors, microRNAs, or small molecules.
 creNET [@doi:10.1038/s41598-018-19635-0] integrates a gene regulatory network, derived from STRING [@doi:10.1093/nar/gku1003], with a sparse logistic regression model to predict phenotypic response in clinical trials for ulcerative colitis and acute kidney rejection based on gene expression data.
-The gene regulatory information allows the model to identify the biological regulators that are related to the response, potentially giving mechanistic insight into differential clinical trial response.
+The gene regulatory information allows the model to identify the biological regulators that are associated with the response, potentially giving mechanistic insight into differential clinical trial response.
 GRRANN [@doi:10.1186/s12859-017-1984-2] uses a gene regulatory network to inform the structure of a neural network, applying it to the same clinical trial data as creNET.
-A number of other methods [@doi:10.1093/nar/gkx681; @doi:10.1093/bioinformatics/bty945] have also used gene regulatory network structure to constrain the structure of a neural network, reducing the number of parameters to be fit by the network and facilitating interpretation of network predictions.
+Several other methods [@doi:10.1093/nar/gkx681; @doi:10.1093/bioinformatics/bty945] have also used gene regulatory network structure to constrain the structure of a neural network, reducing the number of parameters to be fit by the network and facilitating interpretation of network predictions.
 
 ### Applications in genetics
 

--- a/content/04.network-models.md
+++ b/content/04.network-models.md
@@ -8,11 +8,11 @@ This is comparable to the manner in which sequence context encourages models to 
 ### Applications in transcriptomics
 
 Models that take gene expression data as input can benefit from incorporating gene-level relationships.
-One form that this knowledge commonly takes is a binary database of biological pathways, in which each gene is either in or not in each pathway in the database.
-PLIER [@doi:10.1038/s41592-019-0456-1] uses pathway information from MSigDB [@doi:10.1073/pnas.0506580102] and cell type markers to extract a representation of whole blood gene expression data that corresponds to biological processes and reduces technical noise.
-This pathway-aligned representation was used to perform accurate cell type mixture decomposition.
+One form that this knowledge commonly takes is a database of gene sets, which may represent biological pathways or gene signatures related to a biological state of interest.
+PLIER [@doi:10.1038/s41592-019-0456-1] uses gene set information from MSigDB [@doi:10.1073/pnas.0506580102] and cell type markers to extract a representation of whole blood gene expression data that corresponds to biological processes and reduces technical noise.
+The resulting gene set-aligned representation was used to perform accurate cell type mixture decomposition.
 MultiPLIER [@doi:10.1016/j.cels.2019.04.003] applied the PLIER framework to the recount2 gene expression compendium [@doi:10.1038/nbt.3838] to develop a model that shares information across multiple tissues and diseases, including rare diseases with limited sample sizes.
-PASNet [@doi:10.1186/s12859-018-2500-z] uses MSigDB pathway data to inform the structure of a neural network for predicting patient outcomes in glioblastoma multiforme (GBM) from gene expression data.
+PASNet [@doi:10.1186/s12859-018-2500-z] uses data from MSigDB to inform the structure of a neural network for predicting patient outcomes in glioblastoma multiforme (GBM) from gene expression data.
 This approach has the added benefit of straightforward interpretation, as pathway nodes in the network having high weights can be inferred to correspond to important pathways in GBM outcome prediction.
 
 Alternatively, gene-level relationships can take the form of a network.

--- a/content/04.network-models.md
+++ b/content/04.network-models.md
@@ -1,6 +1,6 @@
 ## Network- and pathway-based models
 
-Rather than operating on raw DNA sequence, many machine learning models in biomedicine operate on gene-indexed input.
+Rather than operating on raw DNA sequence, many machine learning models in biomedicine operate on inputs without an intrinsic order.
 For instance, models may make use of gene expression data matrices (e.g. from RNA sequencing or microarray experiments), where each row represents a sample and each column a gene.
 When modeling data that is indexed by gene, one might incorporate knowledge that describes the relationships or correlations between genes, in an effort to take these relationships into account when making predictions or generating a low-dimensional representation of the data.
 This is comparable to the manner in which sequence context encourages models to consider nearby base pairs similarly.

--- a/content/04.network-models.md
+++ b/content/04.network-models.md
@@ -1,14 +1,26 @@
-## Network- and Pathway-Constrained Models
+## Network- and pathway-based models
 
-### Applications in bulk transcriptomics
+Rather than operating on raw DNA sequence, many machine learning models in biomedicine operate on the gene level.
+For instance, models may make use of gene expression data matrices (e.g. from RNA sequencing or microarray experiments), where each row represents a sample and each column a gene.
+When modeling these types of data, one might incorporate knowledge that describes the relationships or correlations between genes, analogous to the manner in which sequence context describes the linear relationships between base pairs.
 
-* 10.1016/j.cels.2019.04.003 (pathways -> transfer learning for rare diseases)
+### Applications in transcriptomics
+
+Models that take gene expression data as input can benefit from incorporating gene-level relationships.
+One form that this knowledge commonly takes is a binary database of biological pathways, in which each gene is either in or not in each pathway in the database.
+PLIER [@doi:10.1038/s41592-019-0456-1] uses pathway information from MSigDB [@doi:10.1073/pnas.0506580102] and cell type markers to extract a representation of whole blood gene expression data that corresponds to biological processes and reduces technical noise.
+This pathway-aligned representation was used to perform accurate cell type mixture decomposition.
+MultiPLIER [@doi:10.1016/j.cels.2019.04.003] applied the PLIER framework to the recount2 gene expression compendium to develop a model that shares information across multiple tissues and diseases, including rare diseases with limited sample sizes.
+PASNet [@doi:10.1186/s12859-018-2500-z] uses MSigDB pathway data to inform the structure of a neural network for predicting patient outcomes in glioblastoma multiforme (GBM) from gene expression data.
+This approach has the added benefit of straightforward interpretation, as pathway nodes in the network having high weights can be inferred to correspond to important pathways in GBM outcome prediction.
+
+
+* 10.1186/s12859-018-2500-z (pathways -> NN structure, for predicting patient outcomes in GBM)
 * 10.1038/s41540-019-0086-3 (PPI + pathways -> phenotype prediction/cancer subtyping)
 * https://arxiv.org/pdf/1906.10670 (HumanBase -> AML drug response prediction)
 * 10.1093/bioinformatics/bty429 (HINT PPI)
 * 10.1038/s41598-017-03141-w (PPI -> mutated cancer gene detection)
 * 10.1371/journal.pcbi.1006657 (PPI + network optimization -> cancer outcome prediction)
-* 10.1186/s12859-018-2500-z (pathways -> NN structure, for predicting patient outcomes in GBM)
 * 10.1186/s12859-017-1984-2 (gene regulatory network -> NN structure, for patient outcomes in
  kidney transplantation and ulcerative colitis)
 * 10.1038/s41598-018-19635-0 (gene regulatory network -> group lasso, same datasets as ^)
@@ -17,7 +29,6 @@
 
 ### Applications in single cell transcriptomics
 
-* 10.1038/s41592-019-0456-1 (pathways -> cell type deconvolution/pathway-level eQTLs)
 * 10.1093/nar/gkx681 (PPI; protein-DNA interactions)
 * 10.1101/544346 (PPI)
 

--- a/content/04.network-models.md
+++ b/content/04.network-models.md
@@ -14,25 +14,24 @@ MultiPLIER [@doi:10.1016/j.cels.2019.04.003] applied the PLIER framework to the 
 PASNet [@doi:10.1186/s12859-018-2500-z] uses MSigDB pathway data to inform the structure of a neural network for predicting patient outcomes in glioblastoma multiforme (GBM) from gene expression data.
 This approach has the added benefit of straightforward interpretation, as pathway nodes in the network having high weights can be inferred to correspond to important pathways in GBM outcome prediction.
 
+Gene-level relationships can also take the form of a network.
+Nodes in these networks typically represent genes, and edges in these networks may represent interactions or correlations between genes, often in a tissue or cell type context of interest.
+netNMF-sc [@doi:10.1101/544346] incorporates coexpression networks [@doi:10.1093/nar/gkw868] as a smoothing term to perform dimension reduction and impute dropouts in single-cell gene expression data.
+The authors show that using a coexpression network to extract a low-dimensional representation increases performance for cell type identification and identification of cell cycle marker genes, both as compared to using raw gene expression data and as compared to other single-cell dimension reduction methods.
+Combining gene expression data with a network-derived smoothing term has also been shown to improve performance at predicting patient drug response in acute myeloid leukemia [@arxiv:1906.10670] and at detecting mutated cancer genes [@doi:10.1038/s41598-017-03141-w].
+PIMKL [@doi:10.1038/s41540-019-0086-3] combines network and pathway data to predict disease-free survival from breast cancer cohorts.
+This method takes as input both RNA-seq gene expression data and copy number alteration data, but can be applied to gene expression data alone as well.
 
-* 10.1186/s12859-018-2500-z (pathways -> NN structure, for predicting patient outcomes in GBM)
-* 10.1038/s41540-019-0086-3 (PPI + pathways -> phenotype prediction/cancer subtyping)
-* https://arxiv.org/pdf/1906.10670 (HumanBase -> AML drug response prediction)
-* 10.1093/bioinformatics/bty429 (HINT PPI)
-* 10.1038/s41598-017-03141-w (PPI -> mutated cancer gene detection)
-* 10.1371/journal.pcbi.1006657 (PPI + network optimization -> cancer outcome prediction)
-* 10.1186/s12859-017-1984-2 (gene regulatory network -> NN structure, for patient outcomes in
- kidney transplantation and ulcerative colitis)
-* 10.1038/s41598-018-19635-0 (gene regulatory network -> group lasso, same datasets as ^)
-* 10.1093/bioinformatics/bty945 (gene regulatory network -> NN structure, for predicting
- gene expression given gene knockouts)
-
-### Applications in single cell transcriptomics
-
-* 10.1093/nar/gkx681 (PPI; protein-DNA interactions)
-* 10.1101/544346 (PPI)
+Gene regulatory networks can also form a useful component of models for gene expression data.
+These networks describe how the expression of genes is modulated by biological regulators such as transcription factors, microRNAs, or small molecules.
+creNET [@doi:10.1038/s41598-018-19635-0] integrates a gene regulatory network, derived from STRING [@doi:10.1093/nar/gku1003], with a sparse logistic regression model to predict phenotypic response in clinical trials for ulcerative colitis and acute kidney rejection based on gene expression data.
+The gene regulatory information allows the model to identify the biological regulators that are related to the response, potentially giving mechanistic insight into differential clinical trial response.
+GRRANN [@doi:10.1186/s12859-017-1984-2] uses a gene regulatory network to inform the structure of a neural network, applying it to the same clinical trial data as creNET.
+A number of other methods [@doi:10.1093/nar/gkx681; @doi:10.1093/bioinformatics/bty945] have also used gene regulatory network structure to constrain the structure of a neural network, reducing the number of parameters to be learned by the network and facilitating interpretation of network predictions.
 
 ### Applications in genetics
+
+* 10.1093/bioinformatics/bty429 (HINT PPI)
 
 1. Genotype-phenotype associations (GWAS/eQTL)
    * 10.1093/bioinformatics/btu293

--- a/content/04.network-models.md
+++ b/content/04.network-models.md
@@ -10,7 +10,7 @@ Models that take gene expression data as input can benefit from incorporating ge
 One form that this knowledge commonly takes is a binary database of biological pathways, in which each gene is either in or not in each pathway in the database.
 PLIER [@doi:10.1038/s41592-019-0456-1] uses pathway information from MSigDB [@doi:10.1073/pnas.0506580102] and cell type markers to extract a representation of whole blood gene expression data that corresponds to biological processes and reduces technical noise.
 This pathway-aligned representation was used to perform accurate cell type mixture decomposition.
-MultiPLIER [@doi:10.1016/j.cels.2019.04.003] applied the PLIER framework to the recount2 gene expression compendium to develop a model that shares information across multiple tissues and diseases, including rare diseases with limited sample sizes.
+MultiPLIER [@doi:10.1016/j.cels.2019.04.003] applied the PLIER framework to the recount2 gene expression compendium [@doi:10.1038/nbt.3838] to develop a model that shares information across multiple tissues and diseases, including rare diseases with limited sample sizes.
 PASNet [@doi:10.1186/s12859-018-2500-z] uses MSigDB pathway data to inform the structure of a neural network for predicting patient outcomes in glioblastoma multiforme (GBM) from gene expression data.
 This approach has the added benefit of straightforward interpretation, as pathway nodes in the network having high weights can be inferred to correspond to important pathways in GBM outcome prediction.
 

--- a/content/04.network-models.md
+++ b/content/04.network-models.md
@@ -1,8 +1,9 @@
 ## Network- and pathway-based models
 
-Rather than operating on raw DNA sequence, many machine learning models in biomedicine operate on the gene level.
+Rather than operating on raw DNA sequence, many machine learning models in biomedicine operate on gene-indexed input.
 For instance, models may make use of gene expression data matrices (e.g. from RNA sequencing or microarray experiments), where each row represents a sample and each column a gene.
-When modeling these types of data, one might incorporate knowledge that describes the relationships or correlations between genes, analogous to the manner in which sequence context describes the linear relationships between base pairs.
+When modeling data that is indexed by gene, one might incorporate knowledge that describes the relationships or correlations between genes, in an effort to take these relationships into account when making predictions or generating a low-dimensional representation of the data.
+This is comparable to the manner in which sequence context encourages models to consider nearby base pairs similarly.
 
 ### Applications in transcriptomics
 
@@ -14,8 +15,8 @@ MultiPLIER [@doi:10.1016/j.cels.2019.04.003] applied the PLIER framework to the 
 PASNet [@doi:10.1186/s12859-018-2500-z] uses MSigDB pathway data to inform the structure of a neural network for predicting patient outcomes in glioblastoma multiforme (GBM) from gene expression data.
 This approach has the added benefit of straightforward interpretation, as pathway nodes in the network having high weights can be inferred to correspond to important pathways in GBM outcome prediction.
 
-Gene-level relationships can also take the form of a network.
-Nodes in these networks typically represent genes, and edges in these networks may represent interactions or correlations between genes, often in a tissue or cell type context of interest.
+Alternatively, gene-level relationships can take the form of a network.
+Nodes in these networks typically represent genes, and real-valued edges in these networks may represent interactions or correlations between genes, often in a tissue or cell type context of interest.
 netNMF-sc [@doi:10.1101/544346] incorporates coexpression networks [@doi:10.1093/nar/gkw868] as a smoothing term to perform dimension reduction and impute dropouts in single-cell gene expression data.
 The authors show that using a coexpression network to extract a low-dimensional representation increases performance for cell type identification and identification of cell cycle marker genes, both as compared to using raw gene expression data and as compared to other single-cell dimension reduction methods.
 Combining gene expression data with a network-derived smoothing term has also been shown to improve performance at predicting patient drug response in acute myeloid leukemia [@arxiv:1906.10670] and at detecting mutated cancer genes [@doi:10.1038/s41598-017-03141-w].
@@ -27,7 +28,7 @@ These networks describe how the expression of genes is modulated by biological r
 creNET [@doi:10.1038/s41598-018-19635-0] integrates a gene regulatory network, derived from STRING [@doi:10.1093/nar/gku1003], with a sparse logistic regression model to predict phenotypic response in clinical trials for ulcerative colitis and acute kidney rejection based on gene expression data.
 The gene regulatory information allows the model to identify the biological regulators that are related to the response, potentially giving mechanistic insight into differential clinical trial response.
 GRRANN [@doi:10.1186/s12859-017-1984-2] uses a gene regulatory network to inform the structure of a neural network, applying it to the same clinical trial data as creNET.
-A number of other methods [@doi:10.1093/nar/gkx681; @doi:10.1093/bioinformatics/bty945] have also used gene regulatory network structure to constrain the structure of a neural network, reducing the number of parameters to be learned by the network and facilitating interpretation of network predictions.
+A number of other methods [@doi:10.1093/nar/gkx681; @doi:10.1093/bioinformatics/bty945] have also used gene regulatory network structure to constrain the structure of a neural network, reducing the number of parameters to be fit by the network and facilitating interpretation of network predictions.
 
 ### Applications in genetics
 


### PR DESCRIPTION
I ended up merging the bulk and single-cell subsections, since I think the distinction is mostly artificial for most of these methods (e.g. PLIER was developed with applications to single-cell data but generalized successfully to bulk data in MultiPLIER, there's really nothing about the method that's specific to the single-cell setting).

Other than that, I struggled a bit with how to organize this - open to feedback or suggestions for alternative approaches. One alternative I thought of is organizing by dimension reduction methods vs. direct prediction (logistic regression/structured NN) methods, but that didn't seem to flow as well to me.